### PR TITLE
RDSとElasticacheのモジュール定義を追加

### DIFF
--- a/examples/chapter13_elasticache_redis/.terraform.lock.hcl
+++ b/examples/chapter13_elasticache_redis/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "3.64.2"
+  hashes = [
+    "h1:eXusrZ56Ye4gprLzI3dXBy50DV+sbY5gOoJ7cNuouzA=",
+    "zh:0b029a2282beabfe410eb2969e18ca773d3473415e442be4dc8ce0eb6d1cd8c5",
+    "zh:3209de3266a1138f1ccb09f094fdd98b6f55afc06e291db0abe092ec5dbe7640",
+    "zh:40648266551631cbc15f8a76e80faf300510e3b38c2544d43fc25e37e6802727",
+    "zh:483c8af92ae70146f2790a70c1a810251e7135aa912b66e769c934eddceebe32",
+    "zh:4d106d8d415d8df342f3f85e58c35418e6c55e3cb7f02897f832cefac4dca68c",
+    "zh:972626a6ddb31d5216606d12ab5c30fbf8d51ed2bbe0efcdd7cffa68c1141557",
+    "zh:a230d55ec52b1695148d40296877ee23e0b302e817154f9b838eb117c87b13fa",
+    "zh:c95fddfbd7f870db949da0601323e866e0f0fb0d4a93e96725ae5b88029e84d5",
+    "zh:ea0c7f568074f835f22273c8e7e61e87f5277e32004c72122915fd3c8df49ccc",
+    "zh:f96d25887e6e2d2ae47659e2c586efea2167995b59a479ae65a02b097da86474",
+    "zh:fe7502d8e52d3b5ccb2b3c178e7ea894344783093aa71ffb20e978914c976182",
+  ]
+}

--- a/examples/chapter13_elasticache_redis/main.tf
+++ b/examples/chapter13_elasticache_redis/main.tf
@@ -1,0 +1,15 @@
+provider "aws" {
+  region = "ap-northeast-1"
+}
+
+module "network" {
+  source = "../../modules/network"
+}
+
+module "redis" {
+  source              = "../../modules/elasticache"
+  vpc_id              = module.network.vpc_id
+  vpc_cidr_blocks     = [module.network.vpc_cider_block]
+  private_subnet_0_id = module.network.private_subnet_0_id
+  private_subnet_1_id = module.network.private_subnet_1_id
+}

--- a/examples/chapter13_elasticache_redis/outputs.tf
+++ b/examples/chapter13_elasticache_redis/outputs.tf
@@ -1,0 +1,19 @@
+# Clusterモード有効時のエンドポイント
+output "redis_configuration_endpoint" {
+  value = module.redis.configuration_endpoint
+}
+
+# Clusterモード無効時のエンドポイント
+output "redis_non_cluster_primary_endpoint" {
+  value = module.redis.non_cluster_primary_endpoint
+}
+
+# Clusterモード無効時の読み込みエンドポイント
+output "redis_non_cluster_reader_endpoint" {
+  value = module.redis.non_cluster_reader_endpoint
+}
+
+# ポート番号
+output "redis_port" {
+  value = module.redis.port
+}

--- a/examples/chapter13_rds_mysql/.terraform.lock.hcl
+++ b/examples/chapter13_rds_mysql/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "3.64.2"
+  hashes = [
+    "h1:eXusrZ56Ye4gprLzI3dXBy50DV+sbY5gOoJ7cNuouzA=",
+    "zh:0b029a2282beabfe410eb2969e18ca773d3473415e442be4dc8ce0eb6d1cd8c5",
+    "zh:3209de3266a1138f1ccb09f094fdd98b6f55afc06e291db0abe092ec5dbe7640",
+    "zh:40648266551631cbc15f8a76e80faf300510e3b38c2544d43fc25e37e6802727",
+    "zh:483c8af92ae70146f2790a70c1a810251e7135aa912b66e769c934eddceebe32",
+    "zh:4d106d8d415d8df342f3f85e58c35418e6c55e3cb7f02897f832cefac4dca68c",
+    "zh:972626a6ddb31d5216606d12ab5c30fbf8d51ed2bbe0efcdd7cffa68c1141557",
+    "zh:a230d55ec52b1695148d40296877ee23e0b302e817154f9b838eb117c87b13fa",
+    "zh:c95fddfbd7f870db949da0601323e866e0f0fb0d4a93e96725ae5b88029e84d5",
+    "zh:ea0c7f568074f835f22273c8e7e61e87f5277e32004c72122915fd3c8df49ccc",
+    "zh:f96d25887e6e2d2ae47659e2c586efea2167995b59a479ae65a02b097da86474",
+    "zh:fe7502d8e52d3b5ccb2b3c178e7ea894344783093aa71ffb20e978914c976182",
+  ]
+}

--- a/examples/chapter13_rds_mysql/main.tf
+++ b/examples/chapter13_rds_mysql/main.tf
@@ -1,0 +1,21 @@
+provider "aws" {
+  region = "ap-northeast-1"
+}
+
+module "network" {
+  source = "../../modules/network"
+}
+
+module "kms" {
+  source = "../../modules/kms"
+}
+
+module "rds_mysql" {
+  source              = "../../modules/rds"
+  vpc_id              = module.network.vpc_id
+  vpc_cidr_blocks     = [module.network.vpc_cider_block]
+  private_subnet_0_id = module.network.private_subnet_0_id
+  private_subnet_1_id = module.network.private_subnet_1_id
+  kms_key_arn         = module.kms.kms_key_arn
+  database_password   = "DummyPassword"
+}

--- a/examples/chapter13_rds_mysql/outputs.tf
+++ b/examples/chapter13_rds_mysql/outputs.tf
@@ -1,0 +1,7 @@
+output "db_instance_id" {
+  value = module.rds_mysql.db_instance_id
+}
+
+output "db_instance_endpoint" {
+  value = module.rds_mysql.db_instance_endpoint
+}

--- a/modules/elasticache/outputs.tf
+++ b/modules/elasticache/outputs.tf
@@ -1,0 +1,19 @@
+# Clusterモード有効時のエンドポイント
+output "configuration_endpoint" {
+  value = aws_elasticache_replication_group.redis.configuration_endpoint_address
+}
+
+# Clusterモード無効時のエンドポイント
+output "non_cluster_primary_endpoint" {
+  value = aws_elasticache_replication_group.redis.primary_endpoint_address
+}
+
+# Clusterモード無効時の読み込みエンドポイント
+output "non_cluster_reader_endpoint" {
+  value = aws_elasticache_replication_group.redis.reader_endpoint_address
+}
+
+# ポート番号
+output "port" {
+  value = aws_elasticache_replication_group.redis.port
+}

--- a/modules/elasticache/redis_config.tf
+++ b/modules/elasticache/redis_config.tf
@@ -1,0 +1,28 @@
+# Redis用のSecurityグループ
+module "redis_sg" {
+  source      = "../security_group"
+  name        = "redis-sg"
+  port        = "6379"
+  vpc_id      = var.vpc_id
+  cidr_blocks = var.vpc_cidr_blocks
+}
+
+resource "aws_elasticache_parameter_group" "redis_parameters" {
+  name   = "redis-parameters"
+  family = "redis6.x"
+
+  # クラスタモードを無効にするパラメータ
+  parameter {
+    name  = "cluster-enabled"
+    value = "no"
+  }
+}
+
+resource "aws_elasticache_subnet_group" "redis_subnet_group" {
+  name = "redis-subnet-group"
+  # マルチAZによる自動フェイルオーバーを有効にするためには複数AZのサブネットを設定する
+  subnet_ids = [
+    var.private_subnet_0_id,
+    var.private_subnet_1_id,
+  ]
+}

--- a/modules/elasticache/redis_replication_group.tf
+++ b/modules/elasticache/redis_replication_group.tf
@@ -1,0 +1,18 @@
+# elastcacheのレプリケーショングループを定義し、Redisサーバーを作成する
+resource "aws_elasticache_replication_group" "redis" {
+  replication_group_id          = "redis" # Redisのエンドポイント用識別子
+  replication_group_description = "redis sample"
+  engine                        = "redis"           # ElastiCacheのエンジン:redis or memcached を選択
+  engine_version                = "6.x"             # バージョン: redis6系は6.xと指定するらしい
+  node_type                     = "cache.m3.medium" # ノード種類を指定(インスタンスタイプ同等)
+  port                          = 6379              # ポート番号
+  security_group_ids            = [module.redis_sg.security_group_id]
+  parameter_group_name          = aws_elasticache_parameter_group.redis_parameters.name
+  subnet_group_name             = aws_elasticache_subnet_group.redis_subnet_group.name
+  number_cache_clusters         = 3                     # ノード数を指定(Optionで無効にしていると関係ない？)
+  automatic_failover_enabled    = true                  # MultiAZによる自動フェイルオーバーを有効にする
+  snapshot_window               = "09:10-10:10"         # スナップショットの作成時刻[UTC](毎日作成)
+  snapshot_retention_limit      = 7                     # スナップショットの保持期間日数
+  maintenance_window            = "mon:10:40-mon:11:40" # メンテナンス日時の指定[UTC]
+  apply_immediately             = false                 # パラメータ変更の即時反映を無効(無効にするとメンテナンス時に反映する)
+}

--- a/modules/elasticache/variables.tf
+++ b/modules/elasticache/variables.tf
@@ -1,0 +1,6 @@
+variable "vpc_id" {}
+variable "vpc_cidr_blocks" {
+  type = list(string)
+}
+variable "private_subnet_0_id" {}
+variable "private_subnet_1_id" {}

--- a/modules/kms/outputs.tf
+++ b/modules/kms/outputs.tf
@@ -1,0 +1,3 @@
+output "kms_key_arn" {
+  value = aws_kms_key.customer_master_key.arn
+}

--- a/modules/rds/database_subnets.tf
+++ b/modules/rds/database_subnets.tf
@@ -1,0 +1,8 @@
+#RDBインスタンスのサブネットグループを定義: マルチAZ対応で複数AZのサブネットを割り当てる
+resource "aws_db_subnet_group" "database_subnet_group" {
+  name = "database-subnet-group"
+  subnet_ids = [
+    var.private_subnet_0_id,
+    var.private_subnet_1_id,
+  ]
+}

--- a/modules/rds/mysql_config.tf
+++ b/modules/rds/mysql_config.tf
@@ -1,0 +1,36 @@
+# MySQLインスタンスのセキュリティグループを定義
+module "mysql_sg" {
+  source      = "../security_group"
+  name        = "mysql-sg"
+  port        = "3306"
+  vpc_id      = var.vpc_id
+  cidr_blocks = var.vpc_cidr_blocks
+}
+# DBパラメータグループでMySQLの設定を定義する
+resource "aws_db_parameter_group" "mysql_parameters" {
+  name   = "mysql-parameters"
+  family = "mysql8.0" # DBエンジン名と(メジャー)バージョンを指定
+
+  #MySQLのエンコーディングにUTF8を指定する
+  parameter {
+    name  = "character_set_database"
+    value = "utf8mb4"
+  }
+
+  parameter {
+    name  = "character_set_server"
+    value = "utf8mb4"
+  }
+}
+
+# DBオプショングループでMySQLに対するプラグインなどのオプションを定義
+resource "aws_db_option_group" "mysql_options" {
+  name                 = "mysql-options"
+  engine_name          = "mysql"
+  major_engine_version = "8.0"
+
+  option {
+    option_name = "MARIADB_AUDIT_PLUGIN" # MariaDB監査プラグイン: DBに対するログオンやクエリを記録するプラグイン
+
+  }
+}

--- a/modules/rds/mysql_instance.tf
+++ b/modules/rds/mysql_instance.tf
@@ -1,0 +1,33 @@
+# MySQLデータベースインスタンスを定義
+resource "aws_db_instance" "mysql" {
+  identifier                 = "mysql"       # DBインスタンスのID(エンドポイントのサブドメインになる)
+  engine                     = "mysql"       # DBエンジン名
+  engine_version             = "8.0.25"      # DBバージョン
+  instance_class             = "db.t3.small" # RDSインスタンスタイプ
+  port                       = 3306          # ポート番号
+  multi_az                   = true          # マルチAZを有効
+  publicly_accessible        = false         # パブリックアクセスを無効
+  vpc_security_group_ids     = [module.mysql_sg.security_group_id]
+  db_subnet_group_name       = aws_db_subnet_group.database_subnet_group.name
+  parameter_group_name       = aws_db_parameter_group.mysql_parameters.name
+  option_group_name          = aws_db_option_group.mysql_options.name
+  storage_type               = "gp2"                 # ストレージタイプ gp2:汎用SSD
+  allocated_storage          = 20                    # 初期ストレージサイズ
+  max_allocated_storage      = 100                   # 最大ストレージサイズ
+  storage_encrypted          = true                  # ディスク暗号化
+  kms_key_id                 = var.kms_key_arn       # KMSの鍵を指定しディスクを暗号化する
+  username                   = "admin"               # マスターユーザー
+  password                   = var.database_password # マスターパスワード
+  backup_window              = "09:10-09:40"         # バックアップの実施時刻[UTC]
+  backup_retention_period    = 30                    # バックアップ期間(最大35日)
+  maintenance_window         = "mon:10:10-mon:10:40" # メンテナンス実施日時[UTC]
+  auto_minor_version_upgrade = false                 # マイナーバージョンの自動アップデートを無効
+  apply_immediately          = false                 # 設定変更の即時反映を無効(無効の場合はメンテナンス実施時)
+  deletion_protection        = false                 # インスタンスの削除保護を無効化(通常は有効。これはデモなので削除可にした)
+  skip_final_snapshot        = true                  # インスタンス削除時のスナップショット取得をスキップ
+
+  lifecycle {
+    # Terraformでマスターパスワードの変更を追従しない > AWS側でパスワードを変更しても無視するようになる > インスタンス作成後にパスワードが変更できる
+    ignore_changes = [password]
+  }
+}

--- a/modules/rds/outputs.tf
+++ b/modules/rds/outputs.tf
@@ -1,0 +1,7 @@
+output "db_instance_id" {
+  value = aws_db_instance.mysql.identifier
+}
+
+output "db_instance_endpoint" {
+  value = aws_db_instance.mysql.endpoint
+}

--- a/modules/rds/variables.tf
+++ b/modules/rds/variables.tf
@@ -1,0 +1,8 @@
+variable "vpc_id" {}
+variable "vpc_cidr_blocks" {
+  type = list(string)
+}
+variable "private_subnet_0_id" {}
+variable "private_subnet_1_id" {}
+variable "kms_key_arn" {}
+variable "database_password" {}


### PR DESCRIPTION
エンジンはRDS > MySQL, Elasticache > Redis
ルートのmain.tf からはまだモジュールを参照するようにしていない。
ECSコンテナからの接続方法が確定してから行う