### PR TITLE
Chapter15 SSHレスオペレーション

### DIFF
--- a/examples/chapter15_session_manager/.terraform.lock.hcl
+++ b/examples/chapter15_session_manager/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "3.65.0"
+  hashes = [
+    "h1:GCDkcISN83t+JK2U+ie3vaECnyxK0Sr6GjO7IrBOVeo=",
+    "zh:108aeaf5e18087d9ac852737a5be1347a28e40825817cc1a29ec523d40268294",
+    "zh:1a719c0c9754f906b2220d3bbf90d483ec0a74cf87768a464d2d657b7901ec6b",
+    "zh:21acdc35ae70a626cbc81eff06181a78843f1ddc2d9200f80fabf2e0466ecbda",
+    "zh:28846628e1a4227a1f2db256d6b22ed36922f37632999af7404aa74703cd9bfb",
+    "zh:32455550dbf86ae07d9782650e86d23c4fa13d7872e48680044692894e8da6ea",
+    "zh:4241246274627c752f9aef2806e810053306001e80fc5b51d27cbe997f75f95e",
+    "zh:5ca0fab3ceb3f41a97c1ebd29561a034cb83fda04da35fd5f8c3c5cb97bb3ea8",
+    "zh:5fed3b79d4ed6424055e8bbfb7a4393e8db5102cdba04b4590f8e0f4194637fb",
+    "zh:99a0bc325b0a59ded1152546c004953a2bb0e110978bf0cc55e1804384941bdb",
+    "zh:e74f9190a417c891992210f9af937ef55749d86a04762d982260fbbc989342a7",
+    "zh:fb6984405ca63d0373bd992ce157e933b8ae9dd94d74b1c5691632f062fe60b2",
+  ]
+}

--- a/examples/chapter15_session_manager/main.tf
+++ b/examples/chapter15_session_manager/main.tf
@@ -1,0 +1,13 @@
+provider "aws" {
+  region = "ap-northeast-1"
+}
+
+module "network" {
+  source = "../../modules/network"
+}
+
+module "ssm_session_manager" {
+  source              = "../../modules/ssm_manager"
+  bucket_common_name  = var.bucket_common_name
+  private_subnet_0_id = module.network.private_subnet_0_id
+}

--- a/examples/chapter15_session_manager/outputs.tf
+++ b/examples/chapter15_session_manager/outputs.tf
@@ -1,0 +1,3 @@
+output "operation_instance_id" {
+  value = module.ssm_session_manager.operation_instance_id
+}

--- a/examples/chapter15_session_manager/variables.tf
+++ b/examples/chapter15_session_manager/variables.tf
@@ -1,0 +1,1 @@
+variable "bucket_common_name" {}

--- a/modules/codepipeline/artifacts_store.tf
+++ b/modules/codepipeline/artifacts_store.tf
@@ -9,4 +9,6 @@ resource "aws_s3_bucket" "artifacts" {
       days = 180
     }
   }
+
+  force_destroy = true
 }

--- a/modules/ssm_manager/ec2_instance_for_ssm.tf
+++ b/modules/ssm_manager/ec2_instance_for_ssm.tf
@@ -1,0 +1,15 @@
+resource "aws_instance" "demo_for_operation" {
+  ami                  = "ami-0c3fd0f5d33134a76" # Amazon Linux2 のAMI
+  instance_type        = "t3.micro"
+  iam_instance_profile = aws_iam_instance_profile.ec2_for_ssm.name
+  subnet_id            = var.private_subnet_0_id
+  # file(./user_data.sh) で組み込みファイルにしてもよかったけど、exampleから呼ぶとパスが変わるので直接スクリプトを定義する
+  user_data = <<EOF
+    #!/bin/sh
+
+    # Dockerをインストールしサービスで起動する
+    amazon-linux-extras install -y docker
+    systemctl start docker
+    systemctl enable docker
+  EOF
+}

--- a/modules/ssm_manager/log_stores.tf
+++ b/modules/ssm_manager/log_stores.tf
@@ -1,0 +1,19 @@
+# S3でログを保存する場合のバケットを定義
+resource "aws_s3_bucket" "operation" {
+  bucket = "operation.${var.bucket_common_name}"
+
+  lifecycle_rule {
+    enabled = true
+    expiration {
+      days = 180
+    }
+  }
+
+  force_destroy = true # デモなので強制削除を有効
+}
+
+# CloudWatch Logsで保存する場合の定義
+resource "aws_cloudwatch_log_group" "operation" {
+  name              = "/operation"
+  retention_in_days = 180
+}

--- a/modules/ssm_manager/outputs.tf
+++ b/modules/ssm_manager/outputs.tf
@@ -1,0 +1,3 @@
+output "operation_instance_id" {
+  value = aws_instance.demo_for_operation.id
+}

--- a/modules/ssm_manager/ssm_document.tf
+++ b/modules/ssm_manager/ssm_document.tf
@@ -1,0 +1,19 @@
+resource "aws_ssm_document" "session_manager_run_shell" {
+  # Session Managerを利用する場合は以下の3つは固定値
+  name            = "SSM-SessionManagerRunShell" # nameは任意だがこの名前にするとAWS CLIを利用するときにオプション指定が省略できるらしい
+  document_type   = "Session"
+  document_format = "JSON"
+
+  # ログの保存先を指定する
+  content = <<EOF
+  {
+    "schemaVersion": "1.0",
+    "description": "Document to hold regional settings for Session Manager",
+    "sessionType": "Standard_Stream",
+    "inputs": {
+      "s3BucketName": "${aws_s3_bucket.operation.id}",
+      "cloudWatchLogGroupName": "${aws_cloudwatch_log_group.operation.name}"
+    }
+  }
+  EOF
+}

--- a/modules/ssm_manager/ssm_policy.tf
+++ b/modules/ssm_manager/ssm_policy.tf
@@ -1,0 +1,42 @@
+# EC2インスタンスに付与するプロファイルで、
+resource "aws_iam_instance_profile" "ec2_for_ssm" {
+  name = "ec2-for-ssm"
+  role = module.ec2_for_ssm_role.iam_role_name
+}
+
+# SSMがアクセスするEC2インスタンスに付与するRole: このインスタンスでECS FargateのようにDockerコンテナを利用することを想定
+module "ec2_for_ssm_role" {
+  source     = "../iam_role"
+  name       = "ec2-for-ssm"
+  identifier = "ec2.amazonaws.com"
+  policy     = data.aws_iam_policy_document.ec2_for_ssm.json
+}
+
+# SSMManagedInstanceCoreポリシーをベースにしたポリシードキュメントを作成
+data "aws_iam_policy_document" "ec2_for_ssm" {
+  source_json = data.aws_iam_policy.ec2_for_ssm.policy
+
+  statement {
+    effect    = "Allow"
+    resources = ["*"]
+
+    # 追加する権限: S3とCloudWatchLogsへの書込み、ECRとSSMパラメータの参照とKMSの複合
+    actions = [
+      "s3:PutObject",
+      "logs:PutLogEvents",
+      "logs:CreateLogStream",
+      "ecr:GetAuthorizationToken",
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:BatchGetImage",
+      "ssm:GetParameter",
+      "ssm:GetParameters",
+      "ssm:GetParametersByPath",
+      "kms:Decrypt",
+    ]
+  }
+}
+
+data "aws_iam_policy" "ec2_for_ssm" {
+  arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}

--- a/modules/ssm_manager/user_data.sh
+++ b/modules/ssm_manager/user_data.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# Dockerをインストールしサービスで起動する
+amazon-linux-extras install -y docker
+systemctl start docker
+systemctl enable docker

--- a/modules/ssm_manager/variables.tf
+++ b/modules/ssm_manager/variables.tf
@@ -1,0 +1,3 @@
+variable "private_subnet_0_id" {}
+variable "bucket_common_name" {}
+


### PR DESCRIPTION
SSMのセッションマネージャーを利用してEC2インスタンスへアクセスするサンプル

- ローカルマシンに別途 Session Manager pluginをインストールしてアクセスする必要がある
- EC2インスタンスにはDockerをインストールするようにしてある
- アクセスログは、S3とCloudWatch Logsにセットするようにしている